### PR TITLE
Make created_at_local not have timezone field

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -648,7 +648,7 @@ class BaseReportSerializer(TaggitSerializer, serializers.ModelSerializer):
 
     created_at = TimezoneAwareDateTimeField(required=True, source="creation_time")
     created_at_local = serializers.SerializerMethodField(
-        help_text="The date and time when the record was created, displayed in the local timezone specified for this entry."
+        help_text="The date and time when the record was created, displayed without timezone field."
     )
     sent_at = TimezoneAwareDateTimeField(required=True, source="phone_upload_time")
     published = serializers.SerializerMethodField()
@@ -659,7 +659,7 @@ class BaseReportSerializer(TaggitSerializer, serializers.ModelSerializer):
     tags = TagListSerializerField(required=False, allow_empty=True)
 
     def get_created_at_local(self, obj) -> datetime:
-        return obj.creation_time_local
+        return obj.creation_time_local.replace(tzinfo=None)
 
     def get_published(self, obj) -> bool:
         return obj.published

--- a/api/tests/integration/bites/create.tavern.yml
+++ b/api/tests/integration/bites/create.tavern.yml
@@ -39,7 +39,7 @@ stages:
         Authorization: "Bearer {app_user_token:s}"
       method: "POST"
       data: &request_bite_data
-        created_at: '2024-01-01T00:00:00Z'
+        created_at: '2024-01-01T01:00:00+01:00'
         sent_at: '2024-01-01T00:30:00Z'
         location.point: !raw '{"latitude": 41.67419, "longitude": 2.79036}'
         location.source: 'auto'
@@ -58,7 +58,7 @@ stages:
         short_id: !anystr
         user_uuid: "{app_user.pk}"
         created_at: '2024-01-01T00:00:00Z'
-        created_at_local: '2024-01-01T01:00:00+01:00'
+        created_at_local: '2024-01-01T01:00:00'
         sent_at: '2024-01-01T00:30:00Z'
         received_at: !re_fullmatch \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z
         updated_at: !re_fullmatch \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z

--- a/api/tests/integration/bites/schema.yml
+++ b/api/tests/integration/bites/schema.yml
@@ -11,7 +11,7 @@ variables:
     short_id: !anystr
     user_uuid: !re_fullmatch "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
     created_at: !re_fullmatch \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z
-    created_at_local: !re_fullmatch \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}([+-]\d{2}:\d{2}|Z)
+    created_at_local: !re_fullmatch \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}
     sent_at: !re_fullmatch \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z
     received_at: !re_fullmatch \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z
     updated_at: !re_fullmatch \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z

--- a/api/tests/integration/breeding_sites/create.tavern.yml
+++ b/api/tests/integration/breeding_sites/create.tavern.yml
@@ -45,7 +45,7 @@ stages:
         photos[0]file: "{test_jpg_image_path}"
         photos[1]file: "{test_png_image_path}"
       data: &request_site_data
-        created_at: '2024-01-01T00:00:00Z'
+        created_at: '2024-01-01T01:00:00+01:00'
         sent_at: '2024-01-01T00:30:00Z'
         location.point: !raw '{"latitude": 41.67419, "longitude": 2.79036}'
         location.source: 'auto'
@@ -62,7 +62,7 @@ stages:
         short_id: !anystr
         user_uuid: "{app_user.pk}"
         created_at: '2024-01-01T00:00:00Z'
-        created_at_local: '2024-01-01T01:00:00+01:00'
+        created_at_local: '2024-01-01T01:00:00'
         sent_at: '2024-01-01T00:30:00Z'
         received_at: !re_fullmatch \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z
         updated_at: !re_fullmatch \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z

--- a/api/tests/integration/breeding_sites/schema.yml
+++ b/api/tests/integration/breeding_sites/schema.yml
@@ -11,7 +11,7 @@ variables:
     short_id: !anystr
     user_uuid: !re_fullmatch "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
     created_at: !re_fullmatch \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z
-    created_at_local: !re_fullmatch \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}([+-]\d{2}:\d{2}|Z)
+    created_at_local: !re_fullmatch \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}
     sent_at: !re_fullmatch \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z
     received_at: !re_fullmatch \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z
     updated_at: !re_fullmatch \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z

--- a/api/tests/integration/identification_tasks/assignments/schema.yml
+++ b/api/tests/integration/identification_tasks/assignments/schema.yml
@@ -13,7 +13,7 @@ variables:
         uuid: !re_fullmatch "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
         locale: !anystr
       created_at: !re_fullmatch \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z
-      created_at_local: !re_fullmatch \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}([+-]\d{2}:\d{2}|Z)
+      created_at_local: !re_fullmatch \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}
       received_at: !re_fullmatch \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z
       location:
         timezone: !anything

--- a/api/tests/integration/identification_tasks/schema.yml
+++ b/api/tests/integration/identification_tasks/schema.yml
@@ -11,7 +11,7 @@ variables:
       short_id: !anystr
       user_uuid: !re_fullmatch "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
       created_at: !re_fullmatch \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z
-      created_at_local: !re_fullmatch \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}([+-]\d{2}:\d{2}|Z)
+      created_at_local: !re_fullmatch \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}
       received_at: !re_fullmatch \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z
       location:
         timezone: !anything

--- a/api/tests/integration/observations/create.tavern.yml
+++ b/api/tests/integration/observations/create.tavern.yml
@@ -45,7 +45,7 @@ stages:
         photos[0]file: "{test_jpg_image_path}"
         photos[1]file: "{test_png_image_path}"
       data: &request_site_data
-        created_at: '2024-01-01T00:00:00Z'
+        created_at: '2024-01-01T01:00:00+01:00'
         sent_at: '2024-01-01T00:30:00Z'
         location.point: !raw '{"latitude": 41.67419, "longitude": 2.79036}'
         location.source: 'auto'
@@ -61,7 +61,7 @@ stages:
         short_id: !anystr
         user_uuid: "{app_user.pk}"
         created_at: '2024-01-01T00:00:00Z'
-        created_at_local: '2024-01-01T01:00:00+01:00'
+        created_at_local: '2024-01-01T01:00:00'
         sent_at: '2024-01-01T00:30:00Z'
         received_at: !re_fullmatch \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z
         updated_at: !re_fullmatch \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z

--- a/api/tests/integration/observations/schema.yml
+++ b/api/tests/integration/observations/schema.yml
@@ -11,7 +11,7 @@ variables:
     short_id: !anystr
     user_uuid: !re_fullmatch "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
     created_at: !re_fullmatch \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z
-    created_at_local: !re_fullmatch \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}([+-]\d{2}:\d{2}|Z)
+    created_at_local: !re_fullmatch \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}
     sent_at: !re_fullmatch \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z
     received_at: !re_fullmatch \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z
     updated_at: !re_fullmatch \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z


### PR DESCRIPTION
Thinking on how SDKs are parsing directly this field.

For example, for Dart, it does not store the TZ and it directly converted to UTC and the original TZ it's lost -> https://github.com/dart-lang/sdk/issues/54993
